### PR TITLE
Added bin so npx works

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "node test.js"
   },
+  "bin": {
+    "unbroken": "./index.js"
+  },
   "author": "Alexander Sklar",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I think this is all that is necessary to so you can just run `npx unbroken` to run the command without having to manually install it first.