### PR TITLE
Fix error when url get has no response

### DIFF
--- a/lib/unbroken.js
+++ b/lib/unbroken.js
@@ -148,33 +148,35 @@ class Checker {
         this.log(`Retrying ${value}`);
       }
 
-      try
-      {
+      try {
         var r = await axios.get(value);
         if (r.status == 200) {
           return true;
         }
       }
       catch (e) {
-        if (e.response.status == 429) {
-          if (this.suppressions.findIndex(x => x == 'HTTP/429') != -1)
-          {
-            return true; // ignore HTTP/429 errors
+        var sleepSeconds = 0;
+        if (e.hasOwnProperty('response')) {
+          if (e.response.status == 429) {
+            if (this.suppressions.findIndex(x => x == 'HTTP/429') != -1)
+            {
+              return true; // ignore HTTP/429 errors
+            }
+
+            const retryAfterSeconds = e.response.headers.hasOwnProperty('retry-after') ? parseInt(e.response.headers['retry-after']) : 0;
+
+            sleepSeconds = ((i + 1) / maxIterations) * retryAfterSeconds;
+
+            // we aren't ignoring HTTP/429... try again after sleeping
+            this.log(`HTTP/429, request retry after ${retryAfterSeconds}s, sleeping for ${sleepSeconds}s`)
+          } else {
+            this.errors.push(`URL not found ${value} while parsing ${filePath} (HTTP ${e.response.status})`);
+            return false;
           }
-
-          const retryAfterSeconds = e.response.headers.hasOwnProperty('retry-after') ? parseInt(e.response.headers['retry-after']) : 0;
-
-          const sleepMs = 100 + (retryAfterSeconds * 1000);
-          // we aren't ignoring HTTP/429... try again after sleeping
-          this.log(`Throttled by HTTP/429, sleeping for ${retryAfterSeconds} seconds as requested`)
-          msleep(sleepMs);
         }
-        else {
-          this.errors.push(`URL not found ${value} while parsing ${filePath} (HTTP ${e.response.status})`);
-          return false;
-        }
-      }
-    }
+        msleep(100 + sleepSeconds * 1000);
+      } //catch
+    } // for
 
     this.errors.push(`URL not found ${value} while parsing ${filePath} after ${maxIterations} retries`);
     return false;


### PR DESCRIPTION
I assumed a response before, but if there's just a networking exception with no response (and therefore, no status) we get a deprecation warning from node that `e.response` is undefined, and node is okay with that now, but at some point doing that will cause node to straight up exit the process.

So if there's no e.response, just sleep 100ms and do the retry.