### PR TITLE
Add support for UNIX-style end-of-line

### DIFF
--- a/lib/unbroken.js
+++ b/lib/unbroken.js
@@ -25,7 +25,7 @@ class Checker {
     const exclusionsFileName = this.options.exclusions || path.join(this.options.dir, '.unbroken_exclusions');
     try {
         const contents = fs.readFileSync(exclusionsFileName).toString()
-                      .split('\r\n')
+                      .split(/\r?\n/)
                       .filter(x => x.trim() != '') || '';
         this.suppressions = contents.filter(x => !x.startsWith('!')).map(x => this.normalizeSlashes(x));
         this.exclusions = contents.filter(x => x.startsWith('!')).map(x => this.normalizeSlashes(path.normalize(x.slice(1))));

--- a/test/TestCases.json
+++ b/test/TestCases.json
@@ -40,7 +40,13 @@
     { "name": "no-exclusions(glob-exclusions)", "expected": 1, "options": { "dir": "test/exclusionsGlob", "local-only": true, "superquiet": true, "exclusions": "test/empty_exclusions" } },
     
     { "name": "local-only(nameCollisions)", "expected": 0, "options": { "dir": "test/nameCollision", "local-only": true, "superquiet": true } },
-    { "name": "no-exclusions(nameCollisions)", "expected": 0, "options": { "dir": "test/nameCollision", "local-only": true, "superquiet": true, "exclusions": "test/empty_exclusions" } }
+    { "name": "no-exclusions(nameCollisions)", "expected": 0, "options": { "dir": "test/nameCollision", "local-only": true, "superquiet": true, "exclusions": "test/empty_exclusions" } },
+
+    { "name": "local-only(CR-exclusions)", "expected": 0, "options": { "dir": "test/exclusionsCR", "local-only": true, "superquiet": true } },
+    { "name": "no-exclusions(CR-exclusions)", "expected": 2, "options": { "dir": "test/exclusionsCR", "local-only": true, "superquiet": true, "exclusions": "test/empty_exclusions" } },
+
+    { "name": "local-only(CRLF-exclusions)", "expected": 0, "options": { "dir": "test/exclusionsCRLF", "local-only": true, "superquiet": true } },
+    { "name": "no-exclusions(CRLF-exclusions)", "expected": 2, "options": { "dir": "test/exclusionsCRLF", "local-only": true, "superquiet": true, "exclusions": "test/empty_exclusions" } }
 
 ]
 }

--- a/test/exclusionsCR/.unbroken_exclusions
+++ b/test/exclusionsCR/.unbroken_exclusions
@@ -1,0 +1,2 @@
+File not found doesntExist.md while parsing test.md
+File not found doesntExistEither.md while parsing test.md

--- a/test/exclusionsCR/test.md
+++ b/test/exclusionsCR/test.md
@@ -1,0 +1,6 @@
+## Some anchor
+
+[Foo](doesntExist.md) 
+
+[Bar](doesntExistEither.md) 
+

--- a/test/exclusionsCRLF/.unbroken_exclusions
+++ b/test/exclusionsCRLF/.unbroken_exclusions
@@ -1,0 +1,2 @@
+File not found doesntExist.md while parsing test.md
+File not found doesntExistEither.md while parsing test.md

--- a/test/exclusionsCRLF/test.md
+++ b/test/exclusionsCRLF/test.md
@@ -1,0 +1,6 @@
+## Some anchor
+
+[Foo](doesntExist.md) 
+
+[Bar](doesntExistEither.md) 
+


### PR DESCRIPTION
* Fixed unbroken.js to split .unbroken_exclusions on either \n or \r\n
* Added tests for multi-line .unbroken_exclusions with either \n or \r\n

Fixes #12 