### PR TITLE
Add URL result cache to checker

### DIFF
--- a/change/unbroken-9371ba3c-3bd7-412a-b5b3-67700504ba05.json
+++ b/change/unbroken-9371ba3c-3bd7-412a-b5b3-67700504ba05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add URL result cache to checker",
+  "packageName": "unbroken",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This PR adds a cache of HTTP response codes for URLs, so that if we
don't check the same URL more than once in a run.

All tests still pass.