### PR TITLE
Block other threads from checking a URL if it's already being checked

### DIFF
--- a/change/unbroken-04694c60-5143-4db8-86cc-fd22f3a46c53.json
+++ b/change/unbroken-04694c60-5143-4db8-86cc-fd22f3a46c53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Block other threads from checking a URL if it's already being checked",
+  "packageName": "unbroken",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Multiple threads can be queued up to validate URLs. So two threads can
see an empty cache and then both run validation.

This PR sets the first thread to put a sentinel value into the cache
that the other threads will spin on, so we actually achieve the result
of only every trying to validate a given URL one time.