### PR TITLE
Added `Accept-Encoding` header with `br` to requests

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -338,7 +338,10 @@ export class Checker {
         try {
           const userAgent = this.options["user-agent"] || DefaultUserAgent;
           const r = await axios.get(value, {
-            headers: { "User-Agent": userAgent },
+            headers: {
+              "User-Agent": userAgent,
+              "Accept-Encoding": "gzip, deflate, br",
+            },
           });
           if (r.status === 200) {
             // Save success response as result

--- a/test/TestCases.json
+++ b/test/TestCases.json
@@ -53,6 +53,8 @@
 
     { "name": "user-agent", "expected": 0, "options": { "dir": "test/userAgent", "superquiet": true} },
 
-    { "name": "throttling", "expected": 0, "options": { "dir": "test/throttling", "local-only": false, "superquiet": true} }
+    { "name": "throttling", "expected": 0, "options": { "dir": "test/throttling", "local-only": false, "superquiet": true} },
+
+    { "name": "br-encoding", "expected": 0, "options": { "dir": "test/brEncoding", "superquiet": true} }
 ]
 }

--- a/test/brEncoding/test.md
+++ b/test/brEncoding/test.md
@@ -1,0 +1,1 @@
+Here is a [link to GitHub Docs](https://docs.github.com/actions). GitHub Docs rejects requests without br encoding.


### PR DESCRIPTION
This PR sets the HTTP header `Accept-Encoding: gzip, deflate, br`, which
is necessary when contacting some sites, like the GitHub Docs site,
which we frequently link to.